### PR TITLE
feat: add experimentation feature

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+ued.js

--- a/scripts/experimentation/index.js
+++ b/scripts/experimentation/index.js
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  getMetadata,
+  sampleRUM,
+  toCamelCase,
+  toClassName,
+} from '../lib-franklin.js';
+
+export const DEFAULT_OPTIONS = {
+  root: '/experiments',
+  configFile: 'manifest.json',
+  metaTag: 'experiment',
+  queryParameter: 'experiment',
+};
+
+/**
+ * Parses the experimentation configuration sheet and creates an internal model.
+ *
+ * Output model is expected to have the following structure:
+ *      {
+ *        id: <string>,
+ *        label: <string>,
+ *        blocks: [<string>]
+ *        audience: Desktop | Mobile,
+ *        status: Active | Inactive,
+ *        variantNames: [<string>],
+ *        variants: {
+ *          [variantName]: {
+ *            label: <string>
+ *            percentageSplit: <number 0-1>,
+ *            pages: <string>,
+ *            blocks: <string>,
+ *          }
+ *        }
+ *      };
+ */
+function parseExperimentConfig(json) {
+  const config = {};
+  try {
+    json.settings.data.forEach((line) => {
+      const key = toCamelCase(line.Name);
+      config[key] = line.Value;
+    });
+    const variants = {};
+    let variantNames = Object.keys(json.experiences.data[0]);
+    variantNames.shift();
+    variantNames = variantNames.map((vn) => toCamelCase(vn));
+    variantNames.forEach((variantName) => {
+      variants[variantName] = {};
+    });
+    let lastKey = 'default';
+    json.experiences.data.forEach((line) => {
+      let key = toCamelCase(line.Name);
+      if (!key) key = lastKey;
+      lastKey = key;
+      const vns = Object.keys(line);
+      vns.shift();
+      vns.forEach((vn) => {
+        const camelVN = toCamelCase(vn);
+        if (key === 'pages' || key === 'blocks') {
+          variants[camelVN][key] = variants[camelVN][key] || [];
+          if (key === 'pages') variants[camelVN][key].push(new URL(line[vn]).pathname);
+          else variants[camelVN][key].push(line[vn]);
+        } else {
+          variants[camelVN][key] = line[vn];
+        }
+      });
+    });
+    config.variants = variants;
+    config.variantNames = variantNames;
+    return config;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('error parsing experiment config:', e, json);
+  }
+  return null;
+}
+
+/**
+ * Gets the experiment name, if any for the page based on env, useragent, queyr params
+ * @returns {string} experimentid
+ */
+export function getExperimentName(tagName) {
+  if (navigator.userAgent.match(/bot|crawl|spider/i)) {
+    return null;
+  }
+
+  return toClassName(getMetadata(tagName)) || null;
+}
+
+export function isValidConfig(config) {
+  if (!config.variantNames
+    || !config.variantNames.length
+    || !config.variants
+    || !Object.values(config.variants).length
+    || !Object.values(config.variants).every((v) => (
+      typeof v === 'object'
+      && !!v.blocks
+      && !!v.pages
+      && (v.percentageSplit === '' || !!v.percentageSplit)
+    ))) {
+    console.warn('Invalid experiment config. Please review your sheet and parser.');
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Gets experiment config from the manifest and transforms it to more easily
+ * consumable structure.
+ *
+ * the manifest consists of two sheets "settings" and "experiences", by default
+ *
+ * "settings" is applicable to the entire test and contains information
+ * like "Audience", "Status" or "Blocks".
+ *
+ * "experience" hosts the experiences in rows, consisting of:
+ * a "Percentage Split", "Label" and a set of "Links".
+ *
+ *
+ * @param {string} experimentId
+ * @param {object} cfg
+ * @returns {object} containing the experiment manifest
+ */
+export function getConfigForInstantExperiment(experimentId, instantExperiment) {
+  const config = {
+    label: `Instant Experiment: ${experimentId}`,
+    audience: '',
+    status: 'Active',
+    id: experimentId,
+    variants: {},
+    variantNames: [],
+  };
+
+  const pages = instantExperiment.split(',').map((p) => new URL(p.trim()).pathname);
+  const evenSplit = 1 / (pages.length + 1);
+
+  config.variantNames.push('control');
+  config.variants.control = {
+    percentageSplit: '',
+    pages: [window.location.pathname],
+    blocks: [],
+    label: 'Control',
+  };
+
+  pages.forEach((page, i) => {
+    const vname = `challenger-${i + 1}`;
+    config.variantNames.push(vname);
+    config.variants[vname] = {
+      percentageSplit: `${evenSplit.toFixed(2)}`,
+      pages: [page],
+      blocks: [],
+      label: `Challenger ${i + 1}`,
+    };
+  });
+
+  return (config);
+}
+
+/**
+ * Gets experiment config from the manifest and transforms it to more easily
+ * consumable structure.
+ *
+ * the manifest consists of two sheets "settings" and "experiences", by default
+ *
+ * "settings" is applicable to the entire test and contains information
+ * like "Audience", "Status" or "Blocks".
+ *
+ * "experience" hosts the experiences in rows, consisting of:
+ * a "Percentage Split", "Label" and a set of "Links".
+ *
+ *
+ * @param {string} experimentId
+ * @param {object} cfg
+ * @returns {object} containing the experiment manifest
+ */
+export async function getConfigForFullExperiment(experimentId, cfg) {
+  const path = `${cfg.root}/${experimentId}/${cfg.configFile}`;
+  try {
+    const resp = await fetch(path);
+    if (!resp.ok) {
+      console.log('error loading experiment config:', resp);
+      return null;
+    }
+    const json = await resp.json();
+    const config = cfg.parser
+      ? cfg.parser(json)
+      : parseExperimentConfig(json);
+    if (!config) {
+      return null;
+    }
+    config.id = experimentId;
+    config.manifest = path;
+    config.basePath = `${cfg.root}/${experimentId}`;
+    return config;
+  } catch (e) {
+    console.log(`error loading experiment manifest: ${path}`, e);
+  }
+  return null;
+}
+
+function getDecisionPolicy(config) {
+  const decisionPolicy = {
+    id: 'content-experimentation-policy',
+    rootDecisionNodeId: 'n1',
+    decisionNodes: [{
+      id: 'n1',
+      type: 'EXPERIMENTATION',
+      experiment: {
+        id: config.id,
+        identityNamespace: 'ECID',
+        randomizationUnit: 'DEVICE',
+        treatments: Object.entries(config.variants).map(([key, props]) => ({
+          id: key,
+          allocationPercentage: props.percentageSplit
+            ? parseFloat(props.percentageSplit) * 100
+            : 100 - Object.values(config.variants).reduce((result, variant) => {
+              // eslint-disable-next-line no-param-reassign
+              result -= parseFloat(variant.percentageSplit || 0) * 100;
+              return result;
+            }, 100),
+        })),
+      },
+    }],
+  };
+  return decisionPolicy;
+}
+
+/**
+ * this is an extensible stub to take on audience mappings
+ * @param {string} audience
+ * @return {boolean} is member of this audience
+ */
+function isValidAudience(audience) {
+  if (audience === 'mobile') {
+    return window.innerWidth < 600;
+  }
+  if (audience === 'desktop') {
+    return window.innerWidth >= 600;
+  }
+  return true;
+}
+
+/**
+ * Replaces element with content from path
+ * @param {string} path
+ * @param {HTMLElement} element
+ * @param {boolean} isBlock
+ */
+async function replaceInner(path, element) {
+  const plainPath = `${path}.plain.html`;
+  try {
+    const resp = await fetch(plainPath);
+    if (!resp.ok) {
+      console.log('error loading experiment content:', resp);
+      return false;
+    }
+    const html = await resp.text();
+    // eslint-disable-next-line no-param-reassign
+    element.innerHTML = html;
+    return true;
+  } catch (e) {
+    console.log(`error loading experiment content: ${plainPath}`, e);
+  }
+  return false;
+}
+
+export async function getConfig(experiment, instantExperiment, config = DEFAULT_OPTIONS) {
+  const usp = new URLSearchParams(window.location.search);
+  const [forcedExperiment, forcedVariant] = usp.has(config.queryParameter) ? usp.get(config.queryParameter).split('/') : [];
+
+  const experimentConfig = instantExperiment
+    ? await getConfigForInstantExperiment(experiment, instantExperiment)
+    : await getConfigForFullExperiment(experiment, config);
+  console.debug(experimentConfig);
+  if (!experimentConfig || (toCamelCase(experimentConfig.status) !== 'active' && !forcedExperiment)) {
+    return null;
+  }
+
+  experimentConfig.run = !!forcedExperiment
+    || isValidAudience(toClassName(experimentConfig.audience));
+  window.hlx = window.hlx || {};
+  window.hlx.experiment = experimentConfig;
+  console.debug('run', experimentConfig.run, experimentConfig.audience);
+  if (!experimentConfig.run) {
+    return null;
+  }
+
+  if (forcedVariant && experimentConfig.variantNames.includes(forcedVariant)) {
+    experimentConfig.selectedVariant = forcedVariant;
+  } else {
+    // eslint-disable-next-line import/extensions
+    const { ued } = await import('./ued.js');
+    const decision = ued.evaluateDecisionPolicy(getDecisionPolicy(experimentConfig), {});
+    experimentConfig.selectedVariant = decision.items[0].id;
+  }
+  return experimentConfig;
+}
+
+export async function runExperiment(experiment, instantExperiment, customOptions) {
+  const options = {
+    ...DEFAULT_OPTIONS,
+    ...customOptions,
+  };
+  const experimentConfig = await getConfig(experiment, instantExperiment, options);
+  if (!experimentConfig || !isValidConfig(experimentConfig)) {
+    return false;
+  }
+
+  console.debug(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
+
+  if (experimentConfig.selectedVariant === experimentConfig.variantNames[0]) {
+    return false;
+  }
+
+  const { pages } = experimentConfig.variants[experimentConfig.selectedVariant];
+  if (!pages.length) {
+    return false;
+  }
+
+  const currentPath = window.location.pathname;
+  const control = experimentConfig.variants[experimentConfig.variantNames[0]];
+  const index = control.pages.indexOf(currentPath);
+  if (index < 0 || pages[index] === currentPath) {
+    return false;
+  }
+
+  // Fullpage content experiment
+  document.body.classList.add(`experiment-${experimentConfig.id}`);
+  const result = await replaceInner(pages[0], document.querySelector('main'));
+  if (!result) {
+    console.debug(`failed to serve variant ${window.hlx.experiment.selectedVariant}. Falling back to ${experimentConfig.variantNames[0]}.`);
+  }
+  document.body.classList.add(`variant-${result ? experimentConfig.selectedVariant : experimentConfig.variantNames[0]}`);
+  sampleRUM('experiment', {
+    source: experimentConfig.id,
+    target: result ? experimentConfig.selectedVariant : experimentConfig.variantNames[0],
+  });
+  return result;
+}
+
+export function patchBlockConfig(config) {
+  const { experiment } = window.hlx;
+
+  // No experiment is running
+  if (!experiment || !experiment.run) {
+    return config;
+  }
+
+  // The current experiment does not modify the block
+  if (experiment.selectedVariant === experiment.variantNames[0]
+    || !experiment.blocks || !experiment.blocks.includes(config.blockName)) {
+    return config;
+  }
+
+  // The current experiment does not modify the block code
+  const variant = experiment.variants[experiment.selectedVariant];
+  if (!variant.blocks.length) {
+    return config;
+  }
+
+  let index = experiment.variants[experiment.variantNames[0]].blocks.indexOf('');
+  if (index < 0) {
+    index = experiment.variants[experiment.variantNames[0]].blocks.indexOf(config.blockName);
+  }
+  if (index < 0) {
+    index = experiment.variants[experiment.variantNames[0]].blocks.indexOf(`/blocks/${config.blockName}`);
+  }
+  if (index < 0) {
+    return config;
+  }
+
+  let origin = '';
+  let path;
+  if (/^https?:\/\//.test(variant.blocks[index])) {
+    const url = new URL(variant.blocks[index]);
+    // Experimenting from a different branch
+    if (url.origin !== window.location.origin) {
+      origin = url.origin;
+    }
+    // Experimenting from a block path
+    if (url.pathname !== '/') {
+      path = url.pathname;
+    } else {
+      path = `/blocks/${config.blockName}`;
+    }
+  } else { // Experimenting from a different branch on the same branch
+    path = variant.blocks[index];
+  }
+  if (!origin && !path) {
+    return config;
+  }
+
+  const { codeBasePath } = window.hlx;
+  return {
+    ...config,
+    cssPath: `${origin}${codeBasePath}${path}/${config.blockName}.css`,
+    jsPath: `${origin}${codeBasePath}${path}/${config.blockName}.js`,
+  };
+}

--- a/scripts/experimentation/index.js
+++ b/scripts/experimentation/index.js
@@ -111,6 +111,13 @@ export function getExperimentName(tagName) {
   return toClassName(getMetadata(tagName)) || null;
 }
 
+/**
+ * Checks whether we have a valid experimentation config.
+ * Mostly used to validate custom parsers.
+ *
+ * @param {object} config the experimentation config
+ * @returns a boolean indicating whether the config is valid or not
+ */
 export function isValidConfig(config) {
   if (!config.variantNames
     || !config.variantNames.length
@@ -141,8 +148,8 @@ export function isValidConfig(config) {
  * a "Percentage Split", "Label" and a set of "Links".
  *
  *
- * @param {string} experimentId
- * @param {object} cfg
+ * @param {string} experimentId the experimentation id
+ * @param {string} instantExperiment the instant experiment config
  * @returns {object} containing the experiment manifest
  */
 export function getConfigForInstantExperiment(experimentId, instantExperiment) {
@@ -193,8 +200,8 @@ export function getConfigForInstantExperiment(experimentId, instantExperiment) {
  * a "Percentage Split", "Label" and a set of "Links".
  *
  *
- * @param {string} experimentId
- * @param {object} cfg
+ * @param {string} experimentId the experimentation id
+ * @param {object} cfg the custom experimentation config
  * @returns {object} containing the experiment manifest
  */
 export async function getConfigForFullExperiment(experimentId, cfg) {
@@ -222,6 +229,11 @@ export async function getConfigForFullExperiment(experimentId, cfg) {
   return null;
 }
 
+/**
+ * Gets the UED compatible decision policy for the specified experimentation config
+ * @param {object} config the experimentation config
+ * @returns the decision policy to run through the UED engine
+ */
 function getDecisionPolicy(config) {
   const decisionPolicy = {
     id: 'content-experimentation-policy',
@@ -292,7 +304,14 @@ async function replaceInner(path, element) {
   return false;
 }
 
-export async function getConfig(experiment, instantExperiment, config = DEFAULT_OPTIONS) {
+/**
+ * Gets the experimentation config for the specified experiment
+ * @param {string} experiment the experiment id
+ * @param {string} [instantExperiment] the instant experiment config
+ * @param {object} [config] the custom config for the experimentation plugin
+ * @returns the experiment configuration
+ */
+export async function getConfig(experiment, instantExperiment = null, config = DEFAULT_OPTIONS) {
   const usp = new URLSearchParams(window.location.search);
   const [forcedExperiment, forcedVariant] = usp.has(config.queryParameter) ? usp.get(config.queryParameter).split('/') : [];
 
@@ -324,6 +343,13 @@ export async function getConfig(experiment, instantExperiment, config = DEFAULT_
   return experimentConfig;
 }
 
+/**
+ * Runs the configured experiments on the current page.
+ * @param {string} experiment the experiment id
+ * @param {string} instantExperiment the instant experiment config
+ * @param {object} customOptions the custom config for the experimentation plugin
+ * @returns a boolean indicating whether the experiment was run successfully or not
+ */
 export async function runExperiment(experiment, instantExperiment, customOptions) {
   const options = {
     ...DEFAULT_OPTIONS,
@@ -366,6 +392,11 @@ export async function runExperiment(experiment, instantExperiment, customOptions
   return result;
 }
 
+/**
+ * Patches the block config for the experimentation use case.
+ * @param {object} config the block config
+ * @returns the patched block config for experimentation
+ */
 export function patchBlockConfig(config) {
   const { experiment } = window.hlx;
 
@@ -425,3 +456,4 @@ export function patchBlockConfig(config) {
     jsPath: `${origin}${codeBasePath}${path}/${config.blockName}.js`,
   };
 }
+window.hlx.patchBlockConfig.push(patchBlockConfig);

--- a/scripts/experimentation/ued.js
+++ b/scripts/experimentation/ued.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+function murmurhash3_32_gc(key, seed) {
+  var remainder = key.length & 3;
+  var bytes = key.length - remainder;
+  var c1 = 0xcc9e2d51;
+  var c2 = 0x1b873593;
+  var h1 = seed;
+  var k1;
+  var h1b;
+  var i = 0;
+  while (i < bytes) {
+      k1 =
+          ((key.charCodeAt(i) & 0xff)) |
+              ((key.charCodeAt(++i) & 0xff) << 8) |
+              ((key.charCodeAt(++i) & 0xff) << 16) |
+              ((key.charCodeAt(++i) & 0xff) << 24);
+      ++i;
+      k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
+      h1 ^= k1;
+      h1 = (h1 << 13) | (h1 >>> 19);
+      h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
+      h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
+  }
+  k1 = 0;
+  switch (remainder) {
+      case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+      case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+      case 1:
+          k1 ^= (key.charCodeAt(i) & 0xff);
+          k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
+          k1 = (k1 << 15) | (k1 >>> 17);
+          k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
+          h1 ^= k1;
+  }
+  h1 ^= key.length;
+  h1 ^= h1 >>> 16;
+  h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+  h1 ^= h1 >>> 13;
+  h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
+  h1 ^= h1 >>> 16;
+  return h1 >>> 0;
+}
+
+var TOTAL_BUCKETS = 10000;
+function getBucket(saltedId) {
+  var hash = murmurhash3_32_gc(saltedId, 0);
+  var hashFixedBucket = Math.abs(hash) % TOTAL_BUCKETS;
+  var bucket = hashFixedBucket / TOTAL_BUCKETS;
+  return bucket;
+}
+function pickWithWeightsBucket(allocationPercentages, treatments, bucket) {
+  var sum = allocationPercentages.reduce(function (partialSum, a) { return partialSum + a; }, 0);
+  var partialSum = 0.0;
+  for (var i = 0; i < treatments.length; i++) {
+      partialSum += Number(allocationPercentages[i].toFixed(2)) / sum;
+      if (bucket > partialSum) {
+          continue;
+      }
+      return treatments[i];
+  }
+}
+function assignTreatmentByVisitor(experimentid, identityId, allocationPercentages, treatments) {
+  var saltedId = experimentid + '.' + identityId;
+  var bucketId = getBucket(saltedId);
+  var treatmentId = pickWithWeightsBucket(allocationPercentages, treatments, bucketId);
+  return {
+      treatmentId: treatmentId,
+      bucketId: bucketId
+  };
+}
+
+var LOCAL_STORAGE_KEY = 'unified-decisioning-experiments';
+function assignTreatment(allocationPercentages, treatments) {
+  var random = Math.random() * 100;
+  var i = treatments.length;
+  while (random > 0 && i > 0) {
+      i -= 1;
+      random -= +allocationPercentages[i];
+  }
+  return treatments[i];
+}
+function getLastExperimentTreatment(experimentId) {
+  var experimentsStr = localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (experimentsStr) {
+      var experiments = JSON.parse(experimentsStr);
+      if (experiments[experimentId]) {
+          return experiments[experimentId].treatment;
+      }
+  }
+  return null;
+}
+function setLastExperimentTreatment(experimentId, treatment) {
+  var experimentsStr = localStorage.getItem(LOCAL_STORAGE_KEY);
+  var experiments = experimentsStr ? JSON.parse(experimentsStr) : {};
+  var now = new Date();
+  var expKeys = Object.keys(experiments);
+  expKeys.forEach(function (key) {
+      var date = new Date(experiments[key].date);
+      if ((now.getTime() - date.getTime()) > (1000 * 86400 * 30)) {
+          delete experiments[key];
+      }
+  });
+  var date = now.toISOString().split('T')[0];
+  experiments[experimentId] = { treatment: treatment, date: date };
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(experiments));
+}
+function assignTreatmentByDevice(experimentId, allocationPercentages, treatments) {
+  var cachedTreatmentId = getLastExperimentTreatment(experimentId);
+  var treatmentIdResponse;
+  if (!cachedTreatmentId) {
+      var assignedTreatmentId = assignTreatment(allocationPercentages, treatments);
+      setLastExperimentTreatment(experimentId, assignedTreatmentId);
+      treatmentIdResponse = assignedTreatmentId;
+  }
+  else {
+      treatmentIdResponse = cachedTreatmentId;
+  }
+  return {
+      treatmentId: treatmentIdResponse
+  };
+}
+
+var RandomizationUnit = {
+  VISITOR: 'VISITOR',
+  DEVICE: 'DEVICE'
+};
+function evaluateExperiment(context, experiment) {
+  var experimentId = experiment.id, identityNamespace = experiment.identityNamespace, _a = experiment.randomizationUnit, randomizationUnit = _a === void 0 ? RandomizationUnit.VISITOR : _a;
+  var identityMap = context.identityMap;
+  var treatments = experiment.treatments.map(function (item) { return item.id; });
+  var allocationPercentages = experiment.treatments.map(function (item) { return item.allocationPercentage; });
+  var treatmentAssignment = null;
+  switch (randomizationUnit) {
+      case RandomizationUnit.VISITOR: {
+          var identityId = identityMap[identityNamespace][0].id;
+          treatmentAssignment = assignTreatmentByVisitor(experimentId, identityId, allocationPercentages, treatments);
+          break;
+      }
+      case RandomizationUnit.DEVICE: {
+          treatmentAssignment = assignTreatmentByDevice(experimentId, allocationPercentages, treatments);
+          break;
+      }
+      default:
+          throw new Error("Unknow randomization unit");
+  }
+  var evaluationResponse = {
+      experimentId: experimentId,
+      hashedBucket: treatmentAssignment.bucketId,
+      treatment: {
+          id: treatmentAssignment.treatmentId
+      }
+  };
+  return evaluationResponse;
+}
+
+function traverseDecisionTree(decisionNodesMap, context, currentNodeId) {
+  var _a = decisionNodesMap[currentNodeId], experiment = _a.experiment, type = _a.type;
+  if (type === 'EXPERIMENTATION') {
+      var treatment = evaluateExperiment(context, experiment).treatment;
+      return [treatment];
+  }
+}
+function evaluateDecisionPolicy(decisionPolicy, context) {
+  var decisionNodesMap = {};
+  decisionPolicy.decisionNodes.forEach(function (item) {
+      decisionNodesMap[item['id']] = item;
+  });
+  var items = traverseDecisionTree(decisionNodesMap, context, decisionPolicy.rootDecisionNodeId);
+  return {
+      items: items
+  };
+}
+
+export const ued = { evaluateDecisionPolicy };

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -340,6 +340,24 @@ export function buildBlock(blockName, content) {
 }
 
 /**
+ * Gets the configuration for the given glock, and also passes
+ * the config to the `patchBlockConfig` methods in the plugins.
+ *
+ * @param {Element} block The block element
+ * @returns {object} The block config (blockName, cssPath and jsPath)
+ */
+function getBlockConfig(block) {
+  const blockName = block.getAttribute('data-block-name');
+  const cssPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`;
+  const jsPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`;
+
+  return window.hlx.patchBlockConfig.reduce(
+    (config, fn) => (typeof fn === 'function' ? fn(config) : config),
+    { blockName, cssPath, jsPath },
+  );
+}
+
+/**
  * Loads JS and CSS for a block.
  * @param {Element} block The block element
  */
@@ -347,15 +365,15 @@ export async function loadBlock(block) {
   const status = block.getAttribute('data-block-status');
   if (status !== 'loading' && status !== 'loaded') {
     block.setAttribute('data-block-status', 'loading');
-    const blockName = block.getAttribute('data-block-name');
+    const { blockName, cssPath, jsPath } = getBlockConfig(block);
     try {
       const cssLoaded = new Promise((resolve) => {
-        loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`, resolve);
+        loadCSS(cssPath, resolve);
       });
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {
-            const mod = await import(`../blocks/${blockName}/${blockName}.js`);
+            const mod = await import(jsPath);
             if (mod.default) {
               await mod.default(block);
             }
@@ -551,6 +569,7 @@ export function setup() {
   window.hlx = window.hlx || {};
   window.hlx.codeBasePath = '';
   window.hlx.lighthouse = new URLSearchParams(window.location.search).get('lighthouse') === 'on';
+  window.hlx.patchBlockConfig = [];
 
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
   if (scriptEl) {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -351,6 +351,10 @@ function getBlockConfig(block) {
   const cssPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`;
   const jsPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`;
 
+  if (!window.hlx.patchBlockConfig) {
+    return { blockName, cssPath, jsPath };
+  }
+
   return window.hlx.patchBlockConfig.reduce(
     (config, fn) => (typeof fn === 'function' ? fn(config) : config),
     { blockName, cssPath, jsPath },

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 window.hlx.RUM_GENERATION = 'project-1'; // add your RUM generation information here
 
+// Define the custom audiences mapping for experimentation
 const EXPERIMENTATION_CONFIG = {
   audiences: {
     device: {
@@ -202,6 +203,7 @@ async function loadLazy(doc) {
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
   sampleRUM.observe(main.querySelectorAll('picture > img'));
 
+  // Load experimentation preview overlay
   if (window.location.hostname === 'localhost' || window.location.hostname.endsWith('.hlx.page')) {
     const preview = await import(`${window.hlx.codeBasePath}/tools/preview/preview.js`);
     await preview.default();
@@ -211,6 +213,7 @@ async function loadLazy(doc) {
     }
   }
 
+  // Mark customer as having viewed the page once
   localStorage.setItem('franklin-visitor-returning', true);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,19 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 window.hlx.RUM_GENERATION = 'project-1'; // add your RUM generation information here
 
+const EXPERIMENTATION_CONFIG = {
+  audiences: {
+    device: {
+      mobile: () => window.innerWidth < 600,
+      desktop: () => window.innerWidth >= 600,
+    },
+    visitor: {
+      new: () => !localStorage.getItem('franklin-visitor-returning'),
+      returning: () => !!localStorage.getItem('franklin-visitor-returning'),
+    },
+  },
+};
+
 /**
  * Determine if we are serving content for the block-library, if so don't load the header or footer
  * @returns {boolean} True if we are loading block library content
@@ -127,7 +140,7 @@ async function loadEager(doc) {
   const instantExperiment = getMetadata('instant-experiment');
   if (instantExperiment || experiment) {
     const { runExperiment } = await import('./experimentation/index.js');
-    await runExperiment(experiment, instantExperiment);
+    await runExperiment(experiment, instantExperiment, EXPERIMENTATION_CONFIG);
   }
 
   // load demo config
@@ -197,6 +210,8 @@ async function loadLazy(doc) {
       experimentation.default();
     }
   }
+
+  localStorage.setItem('franklin-visitor-returning', true);
 }
 
 /**

--- a/tools/preview/experimentation.js
+++ b/tools/preview/experimentation.js
@@ -1,0 +1,245 @@
+/* eslint-disable no-param-reassign */
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  getMetadata,
+  toClassName,
+} from '../../scripts/lib-franklin.js';
+import {
+  createPopupButton,
+  getOverlay,
+} from './preview.js';
+
+const percentformat = new Intl.NumberFormat('en-US', { style: 'percent', maximumSignificantDigits: 2 });
+const countformat = new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 });
+const significanceformat = {
+  format: (value) => {
+    if (value < 0.005) {
+      return 'highly significant';
+    }
+    if (value < 0.05) {
+      return 'significant';
+    }
+    if (value < 0.1) {
+      return 'marginally significant';
+    }
+    return 'not significant';
+  },
+};
+const bigcountformat = {
+  format: (value) => {
+    if (value > 1000000) {
+      return `${countformat.format(value / 1000000)}M`;
+    }
+    if (value > 1000) {
+      return `${countformat.format(value / 1000)}K`;
+    }
+    return countformat.format(value);
+  },
+};
+
+function createVariant(experiment, variantName, config) {
+  const selectedVariant = config?.selectedVariant || config?.variantNames[0];
+  const variant = config.variants[variantName];
+  const split = +variant.percentageSplit
+    || 1 - config.variantNames.reduce((c, vn) => c + +config.variants[vn].percentageSplit, 0);
+  const percentage = percentformat.format(split);
+
+  const experimentURL = new URL(window.location.href);
+  // this will retain other query params such as ?rum=on
+  experimentURL.searchParams.set('experiment', `${experiment}/${variantName}`);
+
+  return {
+    label: `<code>${variantName}</code>`,
+    description: `
+      <p>${variant.label}</p>
+      <p class="percentage">(${percentage} split)</p>
+      <p class="performance"></p>`,
+    actions: [{ label: 'Simulate', href: experimentURL.href }],
+    isSelected: selectedVariant === variantName,
+  };
+}
+
+async function fetchRumData(experiment) {
+  // the query is a bit slow, so I'm only fetching the results when the popup is opened
+  const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments');
+  resultsURL.searchParams.set('experiment', experiment);
+  if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
+    // restrict results to the production host, this also reduces query cost
+    resultsURL.searchParams.set('domain', window.hlx.sidekickConfig.host);
+  }
+
+  const response = await fetch(resultsURL.href);
+  if (!response.ok) {
+    return null;
+  }
+
+  const { results } = await response.json();
+  if (!results.length) {
+    return null;
+  }
+
+  const numberify = (obj) => Object.entries(obj).reduce((o, [k, v]) => {
+    o[k] = Number.parseFloat(v);
+    o[k] = Number.isNaN(o[k]) ? v : o[k];
+    return o;
+  }, {});
+
+  const variantsAsNums = results.map(numberify);
+  const totals = Object.entries(
+    variantsAsNums.reduce((o, v) => {
+      Object.entries(v).forEach(([k, val]) => {
+        if (typeof val === 'number' && Number.isInteger(val) && k.startsWith('variant_')) {
+          o[k] = (o[k] || 0) + val;
+        } else if (typeof val === 'number' && Number.isInteger(val) && k.startsWith('control_')) {
+          o[k] = val;
+        }
+      });
+      return o;
+    }, {}),
+  ).reduce((o, [k, v]) => {
+    o[k] = v;
+    const vkey = k.replace(/^(variant|control)_/, 'variant_');
+    const ckey = k.replace(/^(variant|control)_/, 'control_');
+    const tkey = k.replace(/^(variant|control)_/, 'total_');
+    if (o[ckey] && o[vkey]) {
+      o[tkey] = o[ckey] + o[vkey];
+    }
+    return o;
+  }, {});
+  const richVariants = variantsAsNums
+    .map((v) => ({
+      ...v,
+      allocation_rate: v.variant_experimentations / totals.total_experimentations,
+    }))
+    .reduce((o, v) => {
+      const variantName = v.variant;
+      o[variantName] = v;
+      return o;
+    }, {
+      control: {
+        variant: 'control',
+        ...Object.entries(variantsAsNums[0]).reduce((k, v) => {
+          const [key, val] = v;
+          if (key.startsWith('control_')) {
+            k[key.replace(/^control_/, 'variant_')] = val;
+          }
+          return k;
+        }, {}),
+      },
+    });
+  const winner = variantsAsNums.reduce((w, v) => {
+    if (v.variant_conversion_rate > w.conversion_rate && v.p_value < 0.05) {
+      w.conversion_rate = v.variant_conversion_rate;
+      w.p_value = v.p_value;
+      w.variant = v.variant;
+    }
+    return w;
+  }, { variant: 'control', p_value: 1, conversion_rate: 0 });
+
+  return {
+    richVariants,
+    totals,
+    variantsAsNums,
+    winner,
+  };
+}
+
+function populatePerformanceMetrics(div, config, {
+  richVariants, totals, variantsAsNums, winner,
+}) {
+  // add summary
+  const summary = div.querySelector('.hlx-info');
+  summary.innerHTML = `Showing results for ${bigcountformat.format(totals.total_experimentations)} visits and ${bigcountformat.format(totals.total_conversions)} conversions: `;
+  if (totals.total_conversion_events < 500 && winner.p_value > 0.05) {
+    summary.innerHTML += ` not yet enough data to determine a winner. Keep going until you get ${bigcountformat.format((500 * totals.total_experimentations) / totals.total_conversion_events)} visits.`;
+  } else if (winner.p_value > 0.05) {
+    summary.innerHTML += ' no significant difference between variants. In doubt, stick with <code>control</code>.';
+  } else if (winner.variant === 'control') {
+    summary.innerHTML += ' Stick with <code>control</code>. No variant is better than the control.';
+  } else {
+    summary.innerHTML += ` <code>${winner.variant}</code> is the winner.`;
+  }
+
+  // add traffic allocation to control and each variant
+  config.variantNames.forEach((variantName, index) => {
+    const variantDiv = document.querySelectorAll('.hlx-popup-item')[index];
+    const percentage = variantDiv.querySelector('.percentage');
+    percentage.innerHTML = `
+      <span title="${countformat.format(richVariants[variantName].variant_conversion_events)} real events">${bigcountformat.format(richVariants[variantName].variant_conversions)} clicks</span> /
+      <span title="${countformat.format(richVariants[variantName].variant_experimentation_events)} real events">${bigcountformat.format(richVariants[variantName].variant_experimentations)} visits</span>
+      <span>(${percentformat.format(richVariants[variantName].variant_experimentations / totals.total_experimentations)} split)</span>
+    `;
+  });
+
+  // add click rate and significance to each variant
+  variantsAsNums.forEach((result) => {
+    const variant = document.querySelectorAll('.hlx-popup-item')[config.variantNames.indexOf(result.variant)];
+    if (variant) {
+      const performance = variant.querySelector('.performance');
+      performance.innerHTML = `
+        <span>click rate: ${percentformat.format(result.variant_conversion_rate)}</span>
+        <span>vs. ${percentformat.format(result.control_conversion_rate)}</span>
+        <span title="p value: ${result.p_value}" class="significance ${significanceformat.format(result.p_value).replace(/ /, '-')}">${significanceformat.format(result.p_value)}</span>
+      `;
+    }
+  });
+}
+
+/**
+ * Create Badge if a Page is enlisted in a Helix Experiment
+ * @return {Object} returns a badge or empty string
+ */
+async function decorateExperimentPill(overlay) {
+  const config = window?.hlx?.experiment;
+  const experiment = toClassName(getMetadata('experiment'));
+  console.log('preview experiment', experiment);
+  if (!experiment || !config) {
+    return;
+  }
+
+  const pill = createPopupButton(
+    `Experiment: ${config.id}`,
+    {
+      label: config.label,
+      description: `
+        <div class="hlx-details">
+          ${config.status}${config.audience ? ', ' : ''}${config.audience}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
+        </div>
+        <div class="hlx-info">How is it going?</div>`,
+      actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],
+    },
+    config.variantNames.map((vname) => createVariant(experiment, vname, config)),
+  );
+  pill.classList.add(`is-${toClassName(config.status)}`);
+  overlay.append(pill);
+
+  const performanceMetrics = await fetchRumData(experiment);
+  if (performanceMetrics === null) {
+    return;
+  }
+  populatePerformanceMetrics(pill, config, performanceMetrics);
+}
+
+/**
+ * Decorates Preview mode badges and overlays
+ * @return {Object} returns a badge or empty string
+ */
+export default async function decorateExperimentationOverlay() {
+  try {
+    const overlay = getOverlay();
+    await decorateExperimentPill(overlay);
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/tools/preview/experimentation.js
+++ b/tools/preview/experimentation.js
@@ -48,6 +48,10 @@ const bigcountformat = {
   },
 };
 
+function capitalize(str) {
+  return str.replace(/\w+/g, (word) => word.charAt(0).toUpperCase() + word.substring(1));
+}
+
 function createVariant(experiment, variantName, config) {
   const selectedVariant = config?.selectedVariant || config?.variantNames[0];
   const variant = config.variants[variantName];
@@ -208,13 +212,14 @@ async function decorateExperimentPill(overlay) {
     return;
   }
 
+  const audiences = Object.entries(config.audiences).map(([key, value]) => `${capitalize(key)}: ${capitalize(value)}`).join(', ');
   const pill = createPopupButton(
     `Experiment: ${config.id}`,
     {
       label: config.label,
       description: `
         <div class="hlx-details">
-          ${config.status}${config.audience ? ', ' : ''}${config.audience}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
+          ${config.status}${audiences.length ? `, ${audiences}` : ''}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
         </div>
         <div class="hlx-info">How is it going?</div>`,
       actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],

--- a/tools/preview/preview.css
+++ b/tools/preview/preview.css
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+ .hlx-preview-overlay {
+  z-index: 99;
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  color: #eee;
+  font-weight: 600;
+  font-size: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hlx-badge {
+  border-radius: 32px; 
+  background-color: #888;
+  color: #eee;
+  padding: 16px 32px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+  font-size: inherit;
+  overflow: initial;
+  margin: 0;
+}
+
+.hlx-badge > span {
+  user-select: none;
+}
+
+.hlx-badge .hlx-open {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  width: 22px;
+  height: 22px;
+  border: 2px solid;
+  border-radius: 100px;
+  margin-left: 16px;
+}
+
+.hlx-badge .hlx-open::after {
+  content: "";
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-top: 2px solid;
+  border-right: 2px solid;
+  transform: rotate(-45deg);
+  left: 6px;
+  bottom: 5px;
+}
+
+.hlx-badge.hlx-testing {
+  background-color: #fa0f00;
+  color: #fff;
+}
+
+.hlx-popup {
+  position: absolute;
+  bottom: 64px;
+  right: 0;
+  background-color: #444;
+  min-width: 300px;
+  border-radius: 16px;
+  box-shadow: 0 0 10px #000;
+  font-size: 12px;
+  text-align: initial;
+  white-space: initial;
+}
+
+.hlx-popup a:any-link {
+  color: #eee;
+  border: 2px solid;
+  padding: 5px 12px;
+  display: inline-block;
+  border-radius: 20px;
+  text-decoration: none;
+}
+
+.hlx-popup-header {
+  display: grid;
+  grid-template:
+    "label actions" 
+    "description actions"
+    / 1fr min-content;
+  background-color: #222;
+  border-radius: 16px 16px 0 0;
+  padding: 24px 16px;
+}
+
+.hlx-popup-header-label {
+  grid-area: label;
+}
+
+.hlx-popup-header-description {
+  grid-area: description;
+}
+
+.hlx-popup-header-actions {
+  grid-area: actions;
+  display: flex;
+  flex-direction: column;
+}
+
+.hlx-popup h4, .hlx-popup h5 {
+  margin: 0;
+}
+
+.hlx-popup h4 {
+  font-size: 16px;
+}
+
+.hlx-popup h5 {
+  font-size: 14px;
+}
+
+
+.hlx-popup p {
+  margin: 0;
+}
+
+.hlx-popup::before {
+  content: '';
+  width: 0;
+  height: 0;
+  position: absolute;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;    
+  border-top: 15px solid #444;
+  bottom: -15px;
+  right: 30px;
+}
+
+.hlx-hidden {
+  display: none;
+}
+
+.hlx-badge.is-active,
+.hlx-badge[aria-pressed="true"] {
+  background-color: #280;
+}
+
+.hlx-badge.is-inactive,
+.hlx-badge[aria-pressed="false"] {
+  background-color: #fa0f00;
+}
+
+.hlx-popup-item {
+  display: grid;
+  grid-template:
+    "label actions" 
+    "description actions"
+    / 1fr min-content;
+  margin: 16px;
+  padding: 16px;
+  border-radius: 16px;
+}
+
+.hlx-popup-item-label {
+  grid-area: label;
+}
+
+.hlx-popup-item-description {
+  grid-area: description;
+}
+
+.hlx-popup-item-actions {
+  grid-area: actions;
+  display: flex;
+  flex-direction: column;
+}
+
+.hlx-popup-item.is-selected {
+  background-color: #666;
+}
+
+.hlx-popup-item .hlx-button {
+  flex: 0 0 auto;
+}
+
+@media screen and (min-width: 900px) {
+  .hlx-preview-overlay {
+    flex-flow: row-reverse wrap-reverse;
+    justify-content: flex-start;
+  }  
+}

--- a/tools/preview/preview.css
+++ b/tools/preview/preview.css
@@ -35,6 +35,7 @@
   font-size: inherit;
   overflow: initial;
   margin: 0;
+  text-transform: none;
 }
 
 .hlx-badge > span {

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { loadCSS } from '../../scripts/lib-franklin.js';
+
+function createPreviewOverlay(cls) {
+  const overlay = document.createElement('div');
+  overlay.className = cls;
+  return overlay;
+}
+
+export function createButton(label) {
+  const button = document.createElement('button');
+  button.className = 'hlx-badge';
+  const text = document.createElement('span');
+  text.innerHTML = label;
+  button.append(text);
+  return button;
+}
+
+function createPopupItem(item) {
+  const actions = typeof item === 'object'
+    ? item.actions.map((action) => `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`)
+    : [];
+  const div = document.createElement('div');
+  div.className = `hlx-popup-item${item.isSelected ? ' is-selected' : ''}`;
+  div.innerHTML = `
+    <h5 class="hlx-popup-item-label">${typeof item === 'object' ? item.label : item}</h5>
+    ${item.description ? `<div class="hlx-popup-item-description">${item.description}</div>` : ''}
+    ${actions.length ? `<div class="hlx-popup-item-actions">${actions}</div>` : ''}`;
+  return div;
+}
+
+export function createPopupDialog(header, items = []) {
+  const actions = typeof header === 'object'
+    ? header.actions.map((action) => `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`)
+    : [];
+  const popup = document.createElement('div');
+  popup.className = 'hlx-popup hlx-hidden';
+  popup.innerHTML = `
+    <div class="hlx-popup-header">
+      <h5 class="hlx-popup-header-label">${typeof header === 'object' ? header.label : header}</h5>
+      ${header.description ? `<div class="hlx-popup-header-description">${header.description}</div>` : ''}
+      ${actions.length ? `<div class="hlx-popup-header-actions">${actions}</div>` : ''}
+    </div>
+    <div class="hlx-popup-items"></div>`;
+  const list = popup.querySelector('.hlx-popup-items');
+  items.forEach((item) => {
+    list.append(createPopupItem(item));
+  });
+  return popup;
+}
+
+export function createPopupButton(label, header, items) {
+  const button = createButton(label);
+  const popup = createPopupDialog(header, items);
+  button.innerHTML += '<span class="hlx-open"></span>';
+  button.append(popup);
+  button.addEventListener('click', () => {
+    popup.classList.toggle('hlx-hidden');
+  });
+  return button;
+}
+
+export function createToggleButton(label) {
+  const button = document.createElement('div');
+  button.className = 'hlx-badge';
+  button.role = 'button';
+  button.setAttribute('aria-pressed', false);
+  button.setAttribute('tabindex', 0);
+  const text = document.createElement('span');
+  text.innerHTML = label;
+  button.append(text);
+  button.addEventListener('click', () => {
+    button.setAttribute('aria-pressed', button.getAttribute('aria-pressed') === 'false');
+  });
+  return button;
+}
+
+export function getOverlay() {
+  let overlay = document.querySelector('.hlx-preview-overlay');
+  if (!overlay) {
+    overlay = createPreviewOverlay('hlx-preview-overlay');
+    document.body.append(overlay);
+  }
+  return overlay;
+}
+
+/**
+ * Decorates Preview mode badges and overlays
+ * @return {Object} returns the overlay container
+ */
+export default function decoratePreviewOverlay() {
+  loadCSS(`${window.hlx.codeBasePath}/tools/preview/preview.js`);
+
+  getOverlay();
+}

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -100,7 +100,7 @@ export function getOverlay() {
  * @return {Object} returns the overlay container
  */
 export default function decoratePreviewOverlay() {
-  loadCSS(`${window.hlx.codeBasePath}/tools/preview/preview.js`);
+  loadCSS(`${window.hlx.codeBasePath}/tools/preview/preview.css`);
 
   getOverlay();
 }


### PR DESCRIPTION
This PR adds support for experimentation with custom audiences.

It includes:
- General experimentation logic
- Initial version of the UED engine to select variants
- Custom audiences support. Implemented device (desktop/mobile) and visitor (new/returning) audiences
- Generic preview overlay library
- Experimentation preview overlay pill

Content for the experimentation is available at https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/adobe/wknd/experiments/home-featured/featured-alt2.docx?d=wc71774d7a72c4ba3a44cfdb4ef45dff6&csf=1&web=1&e=8lEFDW
It contains 2 variants of the home page with different featured magazine articles

Test URLs:
- Before: https://main--wknd--hlxsites.hlx.page/
- After: https://experimentation--wknd--hlxsites.hlx.page/
