### PR TITLE
fix: hide sidekick in library

### DIFF
--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -19,6 +19,8 @@
         background-color: #ededed;
         height: 100%;
       }
+      
+      helix-sidekick { display: none }
     </style>
     <title>Sidekick Library</title>
   </head>


### PR DESCRIPTION
Hide the sidekick when viewing the sidekick library

Test URLs:
- Before: https://main--wknd--hlxsites.hlx.page/
- After: https://sidekick-library-migration--wknd--hlxsites.hlx.page/
