### PR TITLE
Asset Catalog integration: Add "Assets" button to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -9,6 +9,13 @@
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
       "url": "/block-library/library",
       "includePaths": [ "**.docx**" ]
+    },
+    {
+      "id": "assets",
+      "title": "AEM Assets",
+      "environments": [ "edit" ],
+      "url": "https://adobe-gmo.findmy.media/",
+      "includePaths": [ "**.docx**" ]
     }
   ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "assets",
-      "title": "AEM Assets",
+      "title": "Assets",
       "environments": [ "edit" ],
       "url": "https://wknd.findmy.media/",
       "includePaths": [ "**.docx**" ]

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -14,7 +14,7 @@
       "id": "assets",
       "title": "AEM Assets",
       "environments": [ "edit" ],
-      "url": "https://adobe-gmo.findmy.media/",
+      "url": "https://wknd.findmy.media/",
       "includePaths": [ "**.docx**" ]
     }
   ]


### PR DESCRIPTION
Adding an Assets button linking to the Asset Catalog space https://wknd.findmy.media, which will soon be available to all Adobe employees.

Test URLs:
- Before: https://main--wknd--hlxsites.hlx.page/
- After: https://cl--wknd--hlxsites.hlx.page/
