### PR TITLE
Add Asset Selector to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -9,11 +9,13 @@
       "includePaths": [ "**.docx**" ]
     },
     {
-      "id": "assets",
-      "title": "Assets",
+      "id": "asset-library",
+      "title": "My Assets",
       "environments": [ "edit" ],
-      "url": "https://wknd.findmy.media/",
-      "includePaths": [ "**.docx**" ]
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html?rail=false",
+      "isPalette": true,
+      "includePaths": [ "**.docx**" ],
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:800px; height: calc(100vh - 60px)"
     }
   ]
 }


### PR DESCRIPTION
Added Asset Selector for AEM CS / Assets Essentials to Sidekick configuration. Browse+search experience is shown and the Selector rail is made wider to make enough space for the browse part.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
