### PR TITLE
#30 - Include document sources to enable a user to explore the 'document based authoring' capability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.hlxignore
+++ b/.hlxignore
@@ -5,3 +5,4 @@ LICENSE
 package.json
 package-lock.json
 test/*
+docs/*

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Before you begin, ensure you have the [AEM Sidekick Chrome extension](https://ch
 [RUM docs](https://www.hlx.live/developer/rum)
 
 - You will need to fork this repository in order to access "Real User Monitoring" (RUM) data, including conversion data, via the Slack Bot
-- In your fork, point fstab.yaml to a SharePoint or Google Drive folder that you own. Extract and upload documents.zip to seed this folder with content
+- In your fork, point fstab.yaml to a SharePoint or Google Drive folder that you own, and is shared with `helix@adobe.com`
+- Extract and upload the contents of `/docs/authoring/documents.zip` to seed this folder with content. Publish the content to your forked site using the AEM Sidekick
 - Install the Github bot on your forked repository using this link: https://github.com/apps/helix-bot/installations/new
 - Using the AEM sidekick, publish the content that you would like to track conversions for (at minimum, the index and adventures documents)
 - For details on project setup, reference the [Developer Tutorial](https://www.hlx.live/developer/tutorial)
@@ -58,8 +59,8 @@ Before you begin, ensure you have the [AEM Sidekick Chrome extension](https://ch
 # Set the value of TEST_URL to your forked site's Preview URL
 WKND_URL=https://main--wknd--<YOUR-GITHUB-USERNAME-OR-ORG>.hlx.live npm run generate-traffic
 
-# For example, using the WKND Demo repository, and running 100 iterations:
-WKND_URL=https://main--wknd--hlxsites.hlx.live ITERATIONS=100 npm run generate-traffic
+# For example, using the WKND Demo repository, and running 1000 iterations:
+WKND_URL=https://main--wknd--hlxsites.hlx.live ITERATIONS=1000 npm run generate-traffic
 ```
 
 ### Slack Bot
@@ -67,6 +68,7 @@ WKND_URL=https://main--wknd--hlxsites.hlx.live ITERATIONS=100 npm run generate-t
 
 - Follow the "Conversion Tracking" steps above to enable the Slack Bot
 - Refer to the [Slack Bot Skills](https://www.hlx.live/docs/slack#slack-bot-skills) section for details on querying the underlying data from Slack
+- To query the performance of an experiment, try the following command: `@Franklin Bot how is experiment experiment-0001 doing?` 
 
 ### Document based content authoring
 [Authoring docs](https://www.hlx.live/docs/authoring)

--- a/docs/authoring/documents.zip
+++ b/docs/authoring/documents.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0700ba9a52f4647dbc0c7b31739a77e0fc5a742e0c861f643073522151b371
+size 104847878


### PR DESCRIPTION
Fix #30

- Add document sources to the repo, via Git LFS (https://git-lfs.com/)
- Add Slack Bot experiment sample query