### PR TITLE
#37 - Featured Article "Read More" CTA button is missing on Preview site

### DIFF
--- a/blocks/featured-article/featured-article.js
+++ b/blocks/featured-article/featured-article.js
@@ -45,6 +45,7 @@ export default async function decorate($block) {
   const $link = document.createElement('div');
   $link.append(link);
   link.textContent = 'Read More';
+  link.className = 'button primary';
 
   const $text = document.createElement('div');
   $text.classList.add('text');


### PR DESCRIPTION
Fix #37 

"Fix" as discussed on Slack.

Test URLs:
- Before: https://main--wknd--hlxsites.hlx.page/
- After: https://blefebvr-read-more-cta--wknd--blefebvre.hlx.page/