### PR TITLE
#43 - The Git-LFS hosted documents.zip is causing bandwidth issues for the hlxsites org

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.zip filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Codebase for the fictional WKND site, showcasing the capabilities of Adobe's Edg
 - Preview: https://main--wknd--hlxsites.hlx.page/
 - Live: https://main--wknd--hlxsites.hlx.live/
 
-## Cloning this repository
-
-This repository uses [Git Large File Storage](https://git-lfs.com/) for `/docs/authoring/documents.zip`. Git-LFS should be installed locally before the repository is cloned.
-
 ## Installation
 
 ```sh
@@ -52,7 +48,8 @@ Before you begin, ensure you have the [AEM Sidekick Chrome extension](https://ch
 
 - You will need to fork this repository in order to access "Real User Monitoring" (RUM) data, including conversion data, via the Slack Bot
 - In your fork, point fstab.yaml to a SharePoint or Google Drive folder that you own, and is shared with `helix@adobe.com`
-- Extract and upload the contents of `/docs/authoring/documents.zip` to seed this folder with content. Publish the content to your forked site using the AEM Sidekick
+- Download `documents.zip` from this project's [Demo Hub page](https://external.adobedemo.com/content/demo-hub/en/demos/external/aem_eds_demo0.html) in the Resources, Assets section. Note: you will need to be logged in to the Demo Hub to access this page
+- Extract and upload the contents of `documents.zip` to seed this folder with content. Publish the content to your forked site using the AEM Sidekick
 - Install the Github bot on your forked repository using this link: https://github.com/apps/helix-bot/installations/new
 - Using the AEM sidekick, publish the content that you would like to track conversions for (at minimum, the index and adventures documents)
 - For details on project setup, reference the [Developer Tutorial](https://www.hlx.live/developer/tutorial)

--- a/docs/authoring/documents.zip
+++ b/docs/authoring/documents.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93d83df15f87a3d630d2dd73c20d6ae7e761101d0b29d6b4634fb7a99151329b
-size 105201442

--- a/test/puppeteer/generate-traffic.mjs
+++ b/test/puppeteer/generate-traffic.mjs
@@ -30,7 +30,7 @@ if (!WKND_URL) {
   for (let i = 0; i < ITERATIONS; i++) {
 
     // First, click through the different sections of the site
-    const headerLinks = ["/magazine", "/adventures", "/faqs", "/about-us"];
+    const headerLinks = ["/magazine", "/adventures", "/faqs"];
     for (const link of headerLinks) {
       // Wait for the page to load, click the next link, then repeat
       const linkSelector = `a[href='${link}']`;


### PR DESCRIPTION
Fix #43

- Remove documents.zip and host it elsewhere
- Remove Git-LFS from the repo

Also: update the generate-traffic script to avoid looking for the about-us link. 